### PR TITLE
Returning JSON strings instead of Generators

### DIFF
--- a/src/api_request.py
+++ b/src/api_request.py
@@ -3,7 +3,7 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_openai import ChatOpenAI
 from constants import LOG
 from sdk.sdk import OpenstackSdk
-import re, json
+import re
 
 
 class openstack_request():
@@ -73,7 +73,7 @@ class openstack_request():
             service = re.findall(r'[A-Z][A-Z\d]+', path)[0]
             if service.lower() in self.enabled_openstack_services:
                 response = eval(path)
-                str_response = f"OpenStack API response = {json.dumps(response)}"
+                str_response = f"OpenStack API response = {response}"
                 return str_response
 
             msg = f"Service {service} is not available in this cluster"

--- a/src/sdk/openstack_services/baremetal/_nodes.py
+++ b/src/sdk/openstack_services/baremetal/_nodes.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,12 +13,14 @@ class Nodes:
 
     def list(self):
         LOG.debug("Trying to fetch nodes")
-        return self.sdk_conn.baremetal.nodes()
+        response = self.sdk_conn.baremetal.nodes()
+        return json.dumps(list(response))
 
-    
+
     def show(self, node_id):
         if not node_id:
             raise AttributeError("Required attribute 'node_id' was not defined")
 
         LOG.debug(f"Trying to find '{node_id}' node")
-        return self.sdk_conn.baremetal.find_node(node_id)
+        response = self.sdk_conn.baremetal.find_node(node_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_availability_zones.py
+++ b/src/sdk/openstack_services/compute/_availability_zones.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,7 +10,8 @@ class AvailabilityZones:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug(f"Trying to fetch availability zones")
-        return self.sdk_conn.compute.availability_zones()
+        response = self.sdk_conn.compute.availability_zones()
+        return json.dumps(list(response))

--- a/src/sdk/openstack_services/compute/_flavors.py
+++ b/src/sdk/openstack_services/compute/_flavors.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,10 +10,11 @@ class Flavors:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug("Trying to fetch flavors")
-        return self.sdk_conn.compute.flavors()
+        response = self.sdk_conn.compute.flavors()
+        return json.dumps(list(response))
 
 
     def show(self, flavor_id):
@@ -20,7 +22,8 @@ class Flavors:
             raise AttributeError("Required attribute 'flavor_id' was not defined")
 
         LOG.debug(f"Trying to find '{flavor_id}' flavor")
-        return self.sdk_conn.compute.find_flavor(flavor_id)
+        response = self.sdk_conn.compute.find_flavor(flavor_id)
+        return json.dumps(response)
 
 
     def show_extra_specs(self, flavor_id):
@@ -28,7 +31,8 @@ class Flavors:
             raise AttributeError("Required attribute 'flavor_id' was not defined")
 
         LOG.debug(f"Trying to find '{flavor_id}' flavor's extra specs")
-        return self.sdk_conn.compute.fetch_flavor_extra_specs(flavor_id)
+        response = self.sdk_conn.compute.fetch_flavor_extra_specs(flavor_id)
+        return json.dumps(list(response))
 
 
     def show_access(self, flavor_id):
@@ -36,4 +40,5 @@ class Flavors:
             raise AttributeError("Required attribute 'flavor_id' was not defined")
 
         LOG.debug(f"Trying to find users who have access to flavor '{flavor_id}'")
-        return self.sdk_conn.compute.get_flavor_access(flavor_id)
+        response = self.sdk_conn.compute.get_flavor_access(flavor_id)
+        return json.dumps(list(response))

--- a/src/sdk/openstack_services/compute/_hypervisors.py
+++ b/src/sdk/openstack_services/compute/_hypervisors.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,10 +10,11 @@ class Hypervisors:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug(f"Trying to fetch hypervisors")
-        return self.sdk_conn.compute.hypervisors()
+        response = self.sdk_conn.compute.hypervisors()
+        return json.dumps(list(response))
 
 
     def show(self, hypervisor_id):
@@ -20,7 +22,8 @@ class Hypervisors:
             raise AttributeError("Required attribute 'hypervisor_id' was not defined")
 
         LOG.debug(f"Trying to find hypervisor '{hypervisor_id}'")
-        return self.sdk_conn.compute.find_hypervisor(hypervisor_id)
+        response = self.sdk_conn.compute.find_hypervisor(hypervisor_id)
+        return json.dumps(response)
 
 
     def show_uptime(self, hypervisor_id):
@@ -28,4 +31,5 @@ class Hypervisors:
             raise AttributeError("Required attribute 'hypervisor_id' was not defined")
 
         LOG.debug(f"Trying to find hypervisor '{hypervisor_id}' uptime")
-        return self.sdk_conn.compute.get_hypervisor_uptime(hypervisor_id)
+        response = self.sdk_conn.compute.get_hypervisor_uptime(hypervisor_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_interfaces.py
+++ b/src/sdk/openstack_services/compute/_interfaces.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,13 +10,14 @@ class ServerInterfaces:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self, server_id):
         if not server_id:
             raise AttributeError("Required attribute 'server_id' was not defined")
 
         LOG.debug(f"Trying to fetch server '{server_id}' interfaces")
-        return self.sdk_conn.compute.server_interfaces(server_id)
+        response = self.sdk_conn.compute.server_interfaces(server_id)
+        return json.dumps(list(response))
 
 
     def show(self, server_id, interface_id):
@@ -26,4 +28,5 @@ class ServerInterfaces:
             raise AttributeError("Required attribute 'interface_id' was not defined")
 
         LOG.debug(f"Trying to find server '{server_id}' '{interface_id}' interface")
-        return self.sdk_conn.compute.get_server_interface(server_id, interface_id)
+        response = self.sdk_conn.compute.get_server_interface(server_id, interface_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_keypairs.py
+++ b/src/sdk/openstack_services/compute/_keypairs.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,10 +10,11 @@ class Keypairs:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug("Trying to fetch keypairs")
-        return self.sdk_conn.compute.keypairs()
+        response = self.sdk_conn.compute.keypairs()
+        return json.dumps(list(response))
 
     
     def show(self, keypair_id):
@@ -20,4 +22,5 @@ class Keypairs:
             raise AttributeError("Required attribute 'keypair_id' was not defined")
 
         LOG.debug(f"Trying to find '{keypair_id}' keypair")
-        return self.sdk_conn.compute.find_keypair(keypair_id)
+        response = self.sdk_conn.compute.find_keypair(keypair_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_security_groups.py
+++ b/src/sdk/openstack_services/compute/_security_groups.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,10 +10,11 @@ class ServerSecurityGroups:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self, server_id):
         if not server_id:
             raise AttributeError("Required attribute 'server_id' was not defined")
 
         LOG.debug(f"Trying to fetch server '{server_id}' security groups")
-        return self.sdk_conn.compute.fetch_server_security_groups(server_id)
+        response = self.sdk_conn.compute.fetch_server_security_groups(server_id)
+        return json.dumps(list(response))

--- a/src/sdk/openstack_services/compute/_server_groups.py
+++ b/src/sdk/openstack_services/compute/_server_groups.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,10 +10,11 @@ class ServerGroups:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug("Trying to fetch server_groups")
-        return self.sdk_conn.compute.server_groups()
+        response = self.sdk_conn.compute.server_groups()
+        return json.dumps(list(response))
 
     
     def show(self, server_group_id):
@@ -20,4 +22,5 @@ class ServerGroups:
             raise AttributeError("Required attribute 'server_group_id' was not defined")
 
         LOG.debug(f"Trying to find '{server_group_id}' server group")
-        return self.sdk_conn.compute.find_server_group(server_group_id)
+        response = self.sdk_conn.compute.find_server_group(server_group_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_servers.py
+++ b/src/sdk/openstack_services/compute/_servers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,10 +10,11 @@ class Servers:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug("Trying to fetch servers")
-        return self.sdk_conn.compute.servers()
+        response = self.sdk_conn.compute.servers()
+        return json.dumps(list(response))
 
     
     def show(self, server_id):
@@ -20,7 +22,8 @@ class Servers:
             raise AttributeError("Required attribute 'server_id' was not defined")
 
         LOG.debug(f"Trying to find '{server_id}' server")
-        return self.sdk_conn.compute.find_server(server_id)
+        response = self.sdk_conn.compute.find_server(server_id)
+        return json.dumps(response)
 
 
     def show_metadata(self, server_id):
@@ -28,4 +31,5 @@ class Servers:
             raise AttributeError("Required attribute 'server_id' was not defined")
 
         LOG.debug(f"Trying to find '{server_id}' server")
-        return self.sdk_conn.compute.get_server_metadata(server_id)
+        response = self.sdk_conn.compute.get_server_metadata(server_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_services.py
+++ b/src/sdk/openstack_services/compute/_services.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,15 +10,17 @@ class Services:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self):
         LOG.debug("Trying to fetch compute services")
-        return self.sdk_conn.compute.services()
+        response = self.sdk_conn.compute.services()
+        return json.dumps(list(response))
 
-    
+
     def show(self, service_id):
         if not service_id:
             raise AttributeError("Required attribute 'service_id' was not defined")
 
         LOG.debug(f"Trying to find '{service_id}' service")
-        return self.sdk_conn.compute.find_service(service_id)
+        response = self.sdk_conn.compute.find_service(service_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/compute/_volume_attachments.py
+++ b/src/sdk/openstack_services/compute/_volume_attachments.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -9,13 +10,14 @@ class ServerVolumeAttachments:
     def __init__(self, conn: Connection):
         self.sdk_conn = conn
 
-    
+
     def list(self, server_id):
         if not server_id:
             raise AttributeError("Required attribute 'server_id' was not defined") 
 
         LOG.debug("Trying to fetch volume attachments for server '{server_id}'")
-        return self.sdk_conn.compute.volume_attachments(server_id)
+        response = self.sdk_conn.compute.volume_attachments(server_id)
+        return json.dumps(list(response))
 
     
     def show(self, server_id, volume_attachment_id):
@@ -26,4 +28,5 @@ class ServerVolumeAttachments:
             raise AttributeError("Required attribute 'volume_attachment_id' was not defined")
 
         LOG.debug(f"Trying to find server '{server_id}' '{volume_attachment_id}' volume attachment")
-        return self.sdk_conn.compute.get_volume_attachment(server_id, volume_attachment_id)
+        response = self.sdk_conn.compute.get_volume_attachment(server_id, volume_attachment_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_credentials.py
+++ b/src/sdk/openstack_services/identity/_credentials.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Credentials:
 
     def list(self):
         LOG.debug("Trying to fetch credentials")
-        return self.sdk_conn.identity.credentials()
+        response = self.sdk_conn.identity.credentials()
+        return json.dumps(list(response))
 
     
     def show(self, credential_id):
@@ -20,4 +22,5 @@ class Credentials:
             raise AttributeError("Required attribute 'credential_id' was not defined")
 
         LOG.debug(f"Trying to find '{credential_id}' credential")
-        return self.sdk_conn.identity.find_credential(credential_id)
+        response = self.sdk_conn.identity.find_credential(credential_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_domains.py
+++ b/src/sdk/openstack_services/identity/_domains.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Domains:
 
     def list(self):
         LOG.debug("Trying to fetch domains")
-        return self.sdk_conn.identity.domains()
+        response = self.sdk_conn.identity.domains()
+        return json.dumps(list(response))
 
     
     def show(self, domain_id):
@@ -20,4 +22,5 @@ class Domains:
             raise AttributeError("Required attribute 'domain_id' was not defined")
 
         LOG.debug(f"Trying to find '{domain_id}' domain")
-        return self.sdk_conn.identity.find_domain(domain_id)
+        response = self.sdk_conn.identity.find_domain(domain_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_endpoints.py
+++ b/src/sdk/openstack_services/identity/_endpoints.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Endpoints:
 
     def list(self):
         LOG.debug("Trying to fetch endpoints")
-        return self.sdk_conn.identity.endpoints()
+        response = self.sdk_conn.identity.endpoints()
+        return json.dumps(list(response))
 
     
     def show(self, endpoint_id):
@@ -20,4 +22,5 @@ class Endpoints:
             raise AttributeError("Required attribute 'endpoint_id' was not defined")
 
         LOG.debug(f"Trying to find '{endpoint_id}' endpoint")
-        return self.sdk_conn.identity.find_endpoint(endpoint_id)
+        response = self.sdk_conn.identity.find_endpoint(endpoint_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_groups.py
+++ b/src/sdk/openstack_services/identity/_groups.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Groups:
 
     def list(self):
         LOG.debug("Trying to fetch groups")
-        return self.sdk_conn.identity.groups()
+        response = self.sdk_conn.identity.groups()
+        return json.dumps(list(response))
 
     
     def show(self, group_id):
@@ -20,7 +22,8 @@ class Groups:
             raise AttributeError("Required attribute 'group_id' was not defined")
 
         LOG.debug(f"Trying to find '{group_id}' group")
-        return self.sdk_conn.identity.find_group(group_id)
+        response = self.sdk_conn.identity.find_group(group_id)
+        return json.dumps(response)
 
 
     def list_users_in_group(self, group_id):
@@ -28,7 +31,8 @@ class Groups:
             raise AttributeError("Required attribute 'group_id' was not defined")
 
         LOG.debug(f"Trying to find users in '{group_id}' group")
-        return self.sdk_conn.identity.group_users(group_id)
+        response = self.sdk_conn.identity.group_users(group_id)
+        return json.dumps(list(response))
 
 
     def check_user_in_group(self, group_id, user_id):
@@ -39,4 +43,5 @@ class Groups:
             raise AttributeError("Required attribute 'user_id' was not defined")
 
         LOG.debug(f"Trying to find user '{user_id}' in '{group_id}' group")
-        return self.sdk_conn.identity.check_user_in_group(user_id, group_id)
+        response = self.sdk_conn.identity.check_user_in_group(user_id, group_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_policies.py
+++ b/src/sdk/openstack_services/identity/_policies.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Policies:
 
     def list(self):
         LOG.debug("Trying to fetch policies")
-        return self.sdk_conn.identity.policies()
+        response = self.sdk_conn.identity.policies()
+        return json.dumps(list(response))
 
     
     def show(self, policy_id):
@@ -20,4 +22,5 @@ class Policies:
             raise AttributeError("Required attribute 'policy_id' was not defined")
 
         LOG.debug(f"Trying to find '{policy_id}' policy")
-        return self.sdk_conn.identity.find_policy(policy_id)
+        response = self.sdk_conn.identity.find_policy(policy_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_projects.py
+++ b/src/sdk/openstack_services/identity/_projects.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Projects:
 
     def list(self):
         LOG.debug("Trying to fetch projects")
-        return self.sdk_conn.identity.projects()
+        response = self.sdk_conn.identity.projects()
+        return json.dumps(list(response))
 
     
     def show(self, project_id):
@@ -20,4 +22,5 @@ class Projects:
             raise AttributeError("Required attribute 'project_id' was not defined")
 
         LOG.debug(f"Trying to find '{project_id}' project")
-        return self.sdk_conn.identity.find_project(project_id)
+        response = self.sdk_conn.identity.find_project(project_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_regions.py
+++ b/src/sdk/openstack_services/identity/_regions.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Regions:
 
     def list(self):
         LOG.debug("Trying to fetch regions")
-        return self.sdk_conn.identity.regions()
+        response = self.sdk_conn.identity.regions()
+        return json.dumps(list(response))
 
     
     def show(self, region_id):
@@ -20,4 +22,5 @@ class Regions:
             raise AttributeError("Required attribute 'region_id' was not defined")
 
         LOG.debug(f"Trying to find '{region_id}' region")
-        return self.sdk_conn.identity.find_region(region_id)
+        response = self.sdk_conn.identity.find_region(region_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_roles.py
+++ b/src/sdk/openstack_services/identity/_roles.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Roles:
 
     def list(self):
         LOG.debug("Trying to fetch roles")
-        return self.sdk_conn.identity.roles()
+        response = self.sdk_conn.identity.roles()
+        return json.dumps(list(response))
 
     
     def show(self, role_id):
@@ -20,4 +22,5 @@ class Roles:
             raise AttributeError("Required attribute 'role_id' was not defined")
 
         LOG.debug(f"Trying to find '{role_id}' role")
-        return self.sdk_conn.identity.find_role(role_id)
+        response = self.sdk_conn.identity.find_role(role_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_services.py
+++ b/src/sdk/openstack_services/identity/_services.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Services:
 
     def list(self):
         LOG.debug("Trying to fetch all services")
-        return self.sdk_conn.identity.services()
+        response = self.sdk_conn.identity.services()
+        return json.dumps(list(response))
 
     
     def show(self, service_id):
@@ -20,4 +22,5 @@ class Services:
             raise AttributeError("Required attribute 'service_id' was not defined")
 
         LOG.debug(f"Trying to find '{service_id}' service")
-        return self.sdk_conn.identity.find_service(service_id)
+        response = self.sdk_conn.identity.find_service(service_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/identity/_users.py
+++ b/src/sdk/openstack_services/identity/_users.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Users:
 
     def list(self):
         LOG.debug("Trying to fetch users")
-        return self.sdk_conn.identity.users()
+        response = self.sdk_conn.identity.users()
+        return json.dumps(list(response))
 
     
     def show(self, user_id):
@@ -20,4 +22,5 @@ class Users:
             raise AttributeError("Required attribute 'user_id' was not defined")
 
         LOG.debug(f"Trying to find '{user_id}' user")
-        return self.sdk_conn.identity.find_user(user_id)
+        response = self.sdk_conn.identity.find_user(user_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/image/_images.py
+++ b/src/sdk/openstack_services/image/_images.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Images:
 
     def list(self):
         LOG.debug("Trying to fetch images")
-        return self.sdk_conn.image.images()
+        response = self.sdk_conn.image.images()
+        return json.dumps(list(response))
 
     
     def show(self, image_id):
@@ -20,4 +22,5 @@ class Images:
             raise AttributeError("Required attribute 'image_id' was not defined")
 
         LOG.debug(f"Trying to find '{image_id}' image")
-        return self.sdk_conn.image.find_image(image_id)
+        response = self.sdk_conn.image.find_image(image_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_agents.py
+++ b/src/sdk/openstack_services/network/_agents.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Agents:
 
     def list(self):
         LOG.debug("Trying to fetch network agents")
-        return self.sdk_conn.network.agents()
+        response = self.sdk_conn.network.agents()
+        return json.dumps(list(response))
 
     
     def show(self, agent_id):
@@ -20,4 +22,5 @@ class Agents:
             raise AttributeError("Required attribute 'agent_id' was not defined")
 
         LOG.debug(f"Trying to find '{agent_id}' network agent")
-        return self.sdk_conn.network.get_agent(agent_id)
+        response = self.sdk_conn.network.get_agent(agent_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_networks.py
+++ b/src/sdk/openstack_services/network/_networks.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Networks:
 
     def list(self):
         LOG.debug("Trying to fetch networks")
-        return self.sdk_conn.network.networks()
+        response = self.sdk_conn.network.networks()
+        return json.dumps(list(response))
 
     
     def show(self, network_id):
@@ -20,4 +22,5 @@ class Networks:
             raise AttributeError("Required attribute 'network_id' was not defined")
 
         LOG.debug(f"Trying to find '{network_id}' network")
-        return self.sdk_conn.network.find_network(network_id)
+        response = self.sdk_conn.network.find_network(network_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_pools.py
+++ b/src/sdk/openstack_services/network/_pools.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Pools:
 
     def list(self):
         LOG.debug("Trying to fetch pools")
-        return self.sdk_conn.network.pools()
+        response = self.sdk_conn.network.pools()
+        return json.dumps(list(response))
 
     
     def show(self, pool_id):
@@ -20,4 +22,5 @@ class Pools:
             raise AttributeError("Required attribute 'pool_id' was not defined")
 
         LOG.debug(f"Trying to find '{pool_id}' pool")
-        return self.sdk_conn.network.find_pool(pool_id)
+        response = self.sdk_conn.network.find_pool(pool_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_ports.py
+++ b/src/sdk/openstack_services/network/_ports.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Ports:
 
     def list(self):
         LOG.debug("Trying to fetch ports")
-        return self.sdk_conn.network.ports()
+        response = self.sdk_conn.network.ports()
+        return json.dumps(list(response))
 
     
     def show(self, port_id):
@@ -20,4 +22,5 @@ class Ports:
             raise AttributeError("Required attribute 'port_id' was not defined")
 
         LOG.debug(f"Trying to find '{port_id}' port")
-        return self.sdk_conn.network.find_port(port_id)
+        response = self.sdk_conn.network.find_port(port_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_routers.py
+++ b/src/sdk/openstack_services/network/_routers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Routers:
 
     def list(self):
         LOG.debug("Trying to fetch routers")
-        return self.sdk_conn.network.routers()
+        response = self.sdk_conn.network.routers()
+        return json.dumps(list(response))
 
     
     def show(self, router_id):
@@ -20,4 +22,5 @@ class Routers:
             raise AttributeError("Required attribute 'router_id' was not defined")
 
         LOG.debug(f"Trying to find '{router_id}' router")
-        return self.sdk_conn.network.find_router(router_id)
+        response = self.sdk_conn.network.find_router(router_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_security_groups.py
+++ b/src/sdk/openstack_services/network/_security_groups.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class SecurityGroups:
 
     def list(self):
         LOG.debug("Trying to fetch security groups")
-        return self.sdk_conn.network.security_groups()
+        response = self.sdk_conn.network.security_groups()
+        return json.dumps(list(response))
 
     
     def show(self, security_group_id):
@@ -20,4 +22,5 @@ class SecurityGroups:
             raise AttributeError("Required attribute 'security_group_id' was not defined")
 
         LOG.debug(f"Trying to find '{security_group_id}' security group")
-        return self.sdk_conn.network.find_security_group(security_group_id)
+        response = self.sdk_conn.network.find_security_group(security_group_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/network/_subnets.py
+++ b/src/sdk/openstack_services/network/_subnets.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Subnets:
 
     def list(self):
         LOG.debug("Trying to fetch subnets")
-        return self.sdk_conn.network.subnets()
+        response = self.sdk_conn.network.subnets()
+        return json.dumps(list(response))
 
     
     def show(self, subnet_id):
@@ -20,4 +22,5 @@ class Subnets:
             raise AttributeError("Required attribute 'subnet_id' was not defined")
 
         LOG.debug(f"Trying to find '{subnet_id}' subnet")
-        return self.sdk_conn.network.find_subnet(subnet_id)
+        response = self.sdk_conn.network.find_subnet(subnet_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/storage/_backend_pools.py
+++ b/src/sdk/openstack_services/storage/_backend_pools.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,4 +13,5 @@ class BackendPools:
 
     def list(self):
         LOG.debug("Trying to fetch storage backend pools")
-        return self.sdk_conn.block_storage.backend_pools()
+        response = self.sdk_conn.block_storage.backend_pools()
+        return json.dumps(list(response))

--- a/src/sdk/openstack_services/storage/_backups.py
+++ b/src/sdk/openstack_services/storage/_backups.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Backups:
 
     def list(self):
         LOG.debug("Trying to fetch backups")
-        return self.sdk_conn.block_storage.backups()
+        response = self.sdk_conn.block_storage.backups()
+        return json.dumps(list(response))
 
     
     def show(self, backup_id):
@@ -20,4 +22,5 @@ class Backups:
             raise AttributeError("Required attribute 'backup_id' was not defined")
 
         LOG.debug(f"Trying to find '{backup_id}' backup")
-        return self.sdk_conn.block_storage.find_backup(backup_id)
+        response = self.sdk_conn.block_storage.find_backup(backup_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/storage/_services.py
+++ b/src/sdk/openstack_services/storage/_services.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Services:
 
     def list(self):
         LOG.debug("Trying to fetch block storage services")
-        return self.sdk_conn.block_storage.services()
+        response = self.sdk_conn.block_storage.services()
+        return json.dumps(list(response))
 
     
     def show(self, service_id):
@@ -20,4 +22,5 @@ class Services:
             raise AttributeError("Required attribute 'service_id' was not defined")
 
         LOG.debug(f"Trying to find '{service_id}' service")
-        return self.sdk_conn.block_storage.find_service(service_id)
+        response = self.sdk_conn.block_storage.find_service(service_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/storage/_snapshots.py
+++ b/src/sdk/openstack_services/storage/_snapshots.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Snapshots:
 
     def list(self):
         LOG.debug("Trying to fetch snapshots")
-        return self.sdk_conn.block_storage.snapshots()
+        response = self.sdk_conn.block_storage.snapshots()
+        return json.dumps(list(response))
 
     
     def show(self, snapshot_id):
@@ -20,7 +22,8 @@ class Snapshots:
             raise AttributeError("Required attribute 'snapshot_id' was not defined")
 
         LOG.debug(f"Trying to find '{snapshot_id}' snapshot")
-        return self.sdk_conn.block_storage.find_snapshot(snapshot_id)
+        response = self.sdk_conn.block_storage.find_snapshot(snapshot_id)
+        return json.dumps(response)
 
 
     def show_metadata(self, snapshot_id):
@@ -28,4 +31,5 @@ class Snapshots:
             raise AttributeError("Required attribute 'snapshot_id' was not defined")
 
         LOG.debug(f"Trying to find '{snapshot_id}' snapshot's metadata")
-        return self.sdk_conn.block_storage.get_snapshot_metadata(snapshot_id)
+        response = self.sdk_conn.block_storage.get_snapshot_metadata(snapshot_id)
+        return json.dumps(response)

--- a/src/sdk/openstack_services/storage/_volumes.py
+++ b/src/sdk/openstack_services/storage/_volumes.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from openstack.connection import Connection
 
@@ -12,7 +13,8 @@ class Volumes:
 
     def list(self):
         LOG.debug("Trying to fetch volumes")
-        return self.sdk_conn.block_storage.volumes()
+        response = self.sdk_conn.block_storage.volumes()
+        return json.dumps(list(response))
 
     
     def show(self, volume_id):
@@ -20,7 +22,8 @@ class Volumes:
             raise AttributeError("Required attribute 'volume_id' was not defined")
 
         LOG.debug(f"Trying to find '{volume_id}' volume")
-        return self.sdk_conn.block_storage.find_volume(volume_id)
+        response = self.sdk_conn.block_storage.find_volume(volume_id)
+        return json.dumps(response)
 
 
     def show_metadata(self, volume_id):
@@ -28,4 +31,5 @@ class Volumes:
             raise AttributeError("Required attribute 'volume_id' was not defined")
 
         LOG.debug(f"Trying to find '{volume_id}' volume's metadata")
-        return self.sdk_conn.block_storage.get_volume_metadata(volume_id)
+        response = self.sdk_conn.block_storage.get_volume_metadata(volume_id)
+        return json.dumps(response)

--- a/src/sdk/sdk.py
+++ b/src/sdk/sdk.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, sys, json
 import logging
 import openstack
 from openstack.connection import Connection
@@ -79,15 +79,14 @@ class OpenstackSdk:
 
     def list_active_openstack_services(self):
         sdk_services_response = self.IDENTITY.services.list()
+        sdk_services = json.loads(sdk_services_response)
         active_services = []
-        for service in sdk_services_response:
-            if service.is_enabled:
-                active_services.append(service.name)
+        for service in sdk_services:
+            if service["is_enabled"]:
+                active_services.append(service["name"])
         return active_services
 
 
 # For testing purposes, run this file directly
 if __name__ == "__main__":
     sdk = OpenstackSdk()
-    teste = 'sdk.COMPUTE.servers.show("test-vm")'
-    print(eval(teste))


### PR DESCRIPTION
The OpenstackSDK functions return list / object generators. Instead of letting the api_response.py know if it is an object or a list, treat these in the functions that return them instead.

Sorry for the long commit (again), but the change is pretty simple, it adds `import json` to all sdk service files and instead of returning the sdk call itself, it uses:
return json.dumps(list(response)) to lists, and
return json.dumps(response) to objects