### PR TITLE
Initial changes from openai to boto3

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -3,3 +3,5 @@ import logging
 CLIENT_ERROR_MSG = "No Wind River/Kubernetes API capable of answering your question was found!\nPleasy try again with another prompt."
 
 LOG = logging.getLogger("chatbot")
+
+MODEL = 'meta.llama2-13b-chat-v1'


### PR DESCRIPTION
# Description

Where the code directly calls OpenAI API, it changes the LLM to boto3.bedrock. There are 3 places where this call is done, one in the decision about positive and negative response (app.py - 107), one for the keys validation (app.py - 158), and one for choosing which system will be queried (app.py - 215)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Pass for choosing the right sentiment (positive or negative) for various different scenarios.
- [x] Pass for validation of credentials
- [x] Pass for choosing the right system to be queried

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules