### PR TITLE
Changing all references of OpenAI to Bedrock

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-openai_key=<key>
 oam_ip=<ip>
 user=<horizon user>
 password=<horizon password>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     volumes:
       - ./subclouds.json:/app/src/subclouds.json
     environment:
-      OPENAI_API_KEY: ${openai_key}
       OAM_IP: ${oam_ip}
       WR_USER: ${user}
       WR_PASSWORD: ${password}

--- a/src/api_request.py
+++ b/src/api_request.py
@@ -38,21 +38,10 @@ class k8s_request:
         format_response = "api: <api_completion>"
 
         # Create prompt
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                (
-                    "system",
-                    f"You are an API generator, based on the user input you will suggest the best API endpoint to retrieve the information from a kubernetes cluster.\n\nYou will only provide the API information that comes after the IP:PORT.\n\nMake sure the provided endpoint is a valid one.\n\nAlso make sure to only provide the API endpoint following the format: {format_response}. Guarantee that the format is followed.",
-                ),
-                ("user", "{input}"),
-            ]
-        )
-
-        output_parser = StrOutputParser()
-        chain = prompt | self.llm | output_parser
+        prompt = f"<s>[INST] <<SYS>>You are an API generator, based on the user input you will suggest the best API endpoint to retrieve the information from a kubernetes cluster. You will only provide the API information that comes after the IP:PORT. Make sure the provided kubernetes endpoint exists before answering. Also make sure to only provide the API endpoint following the format: {format_response}. Don't add any other text besides what the format dictates. Do not acknowledge my request with 'sure' or in any other way besides going straight to the answer. Guarantee that the format is followed.<</SYS>>User query: {self.query}[/INST]"
 
         # Get completion
-        completion = chain.invoke({"input": self.query})
+        completion = self.llm.invoke(prompt).lower()
         if len(completion.split(":")) > 1:
             clean_completion = completion.split(":")[1].strip()
         else:

--- a/src/app.py
+++ b/src/app.py
@@ -169,7 +169,8 @@ def is_api_key_valid():
 
 def define_api_pool(query, session):
     # Use LLM to decide if Kubernetes or Wind River API pool should be used.
-    prompt = f"<s>[INST] <<SYS>>You are an AI connected to a Wind River system and based on the user query you will define which set of APIs is best to retrieve the necessary information to answer the question. Based on the following query you will choose between Wind River APIs and Kubernetes APIs. You will not provide that specific API, only inform if it is a Wind River or a Kubernetes API. Output the answer in the following format 'response: single_word_answer'.<</SYS>> Example: 'List my active alarms. [\INST] Wind River' </s> [INST] User query:{query} [/INST]"  # noqa: E501,W605
+    system_prompt = "You are an AI assistant connected to a Wind River system and based on the user query you will define which set of APIs is best to retrieve the necessary information to answer the question. Based on the following query you will choose between Wind River APIs and Kubernetes APIs. You will not provide that specific API, only inform if it is a Wind River or a Kubernetes API. Do not acknowledge my request with 'sure' or in any other way besides going straight to the answer. Your answer should not contain the word API"  # noqa: E501,W605
+    prompt = f"<s>[INST] <<SYS>>{system_prompt}<</SYS>> Example: 'List my active alarms. [\INST] Wind River' </s> [INST] User query:{query} [/INST]"  # noqa: E501,W605
     response = session["llm"].invoke(prompt).lower()
 
     print(f"###########{response}", file=sys.stderr)

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,6 @@ api.add_resource(Session, '/session')
 
 
 if __name__ == "__main__":
-    chat.set_openai_key()
+    chat.is_api_key_valid()
     chat.initiate_sessions()
     app.run(host="0.0.0.0", port=2000)


### PR DESCRIPTION
# Description

This change modifies all references to OpenAI and langchain-openai to Bedrock ad langchain-bedrock.
It updates one prompt that was not working well with the LlaMa 2 model and added a noqa comment on all the prompt strings, so flake8 ignore them.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Build Docker image
- [x] Run API on Docker compose
- [x] Issue `curl -H "temperature:0" -H "model:meta.llama2-13b-chat-v1" [http://localhost:2000/session](http://localhost:2000/session))` to get the session ID
- [x] Issue `curl -i -H "Content-Type: application/json" -d '{"message": "Is there any active alarms?", "session_id": "'"$SESSION_TOKEN"'"}' http://localhost:2000/chat`. Command ran without errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
