### PR TITLE
Prompt engineering LlaMa 2

### DIFF
--- a/src/api_request.py
+++ b/src/api_request.py
@@ -6,7 +6,7 @@ import requests
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
-from constants import CLIENT_ERROR_MSG, LOG
+from constants import CLIENT_ERROR_MSG, LLAMA_PROMPT_END, LOG
 
 
 class k8s_request:
@@ -38,7 +38,7 @@ class k8s_request:
         format_response = "api: <api_completion>"
 
         # Create prompt
-        prompt = f"<s>[INST] <<SYS>>You are an API generator, based on the user input you will suggest the best API endpoint to retrieve the information from a kubernetes cluster. You will only provide the API information that comes after the IP:PORT. Make sure the provided kubernetes endpoint exists before answering. Also make sure to only provide the API endpoint following the format: {format_response}. Don't add any other text besides what the format dictates. Do not acknowledge my request with 'sure' or in any other way besides going straight to the answer. Guarantee that the format is followed.<</SYS>>User query: {self.query}[/INST]"
+        prompt = f"<s>[INST] <<SYS>>You are an API generator, based on the user input you will suggest the best API endpoint to retrieve the information from a kubernetes cluster. You will only provide the API information that comes after the IP:PORT. Make sure the provided kubernetes endpoint exists before answering. Also make sure to only provide the API endpoint following the format: {format_response}. Don't add any other text besides what the format dictates. {LLAMA_PROMPT_END}.<</SYS>>User query: {self.query}[/INST]"  # noqa: E501
 
         # Get completion
         completion = self.llm.invoke(prompt).lower()
@@ -93,7 +93,10 @@ class k8s_request:
             LOG.info(f'API address: {api_endpoint}')
             response = requests.get(api_endpoint, headers=headers, verify=False)
         except Exception as e:
-            error = f"An error ocurred while trying to retrieve the information, please rewrite the question and try again.\n Error: {e}"
+            error = (
+                f"An error ocurred while trying to retrieve the information, "
+                f"please rewrite the question and try again.\n Error: {e}"
+            )
             LOG.warning(error)
             return error
 
@@ -186,7 +189,10 @@ class wr_request:
             LOG.info(f'API address: {url}')
             response = requests.get(url, headers=headers, verify=False)
         except Exception as e:
-            error = f"An error ocurred while trying to retrieve the information, please rewrite the question and try again.\n Error: {e}"
+            error = (
+                f"An error ocurred while trying to retrieve the information, please "
+                f"rewrite the question and try again.\n Error: {e}"
+            )
             LOG.warning(error)
             return error
 
@@ -220,7 +226,10 @@ class wr_request:
         try:
             response = requests.post(url, headers=headers, json=data, verify=False)
         except Exception as e:
-            error = f"An error ocurred while trying to retrieve the authentication for the Wind River APIs. Error:{e}"
+            error = (
+                f"An error ocurred while trying to retrieve the authentication for the "
+                f"Wind River APIs. Error:{e}"
+            )
             LOG.error(error)
             return error
 
@@ -230,6 +239,9 @@ class wr_request:
 
             return x_auth_token
         else:
-            error = f"Error trying to retrieve authentication token:\n {response.status_code}, {response.text}"
+            error = (
+                f"Error trying to retrieve authentication token:\n {response.status_code}, "
+                f"{response.text}"
+            )
             LOG.warning(error)
             return error

--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,7 @@ from langchain_community.llms import Bedrock
 from langchain_community.vectorstores import Chroma
 
 from api_request import k8s_request, wr_request
-from constants import CLIENT_ERROR_MSG, LOG, MODEL
+from constants import CLIENT_ERROR_MSG, LLAMA_PROMPT_END, LOG, MODEL
 
 
 def initiate_sessions():
@@ -169,7 +169,7 @@ def is_api_key_valid():
 
 def define_api_pool(query, session):
     # Use LLM to decide if Kubernetes or Wind River API pool should be used.
-    system_prompt = "You are an AI assistant connected to a Wind River system and based on the user query you will define which set of APIs is best to retrieve the necessary information to answer the question. Based on the following query you will choose between Wind River APIs and Kubernetes APIs. You will not provide that specific API, only inform if it is a Wind River or a Kubernetes API. Do not acknowledge my request with 'sure' or in any other way besides going straight to the answer. Your answer should not contain the word API"  # noqa: E501,W605
+    system_prompt = f"You are an AI assistant connected to a Wind River system and based on the user query you will define which set of APIs is best to retrieve the necessary information to answer the question. Based on the following query you will choose between Wind River APIs and Kubernetes APIs. You will not provide that specific API, only inform if it is a Wind River or a Kubernetes API. Your answer should not contain the word API. {LLAMA_PROMPT_END}"  # noqa: E501,W605
     prompt = f"<s>[INST] <<SYS>>{system_prompt}<</SYS>> Example: 'List my active alarms. [\INST] Wind River' </s> [INST] User query:{query} [/INST]"  # noqa: E501,W605
     response = session["llm"].invoke(prompt).lower()
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,7 +1,9 @@
 import logging
 
-CLIENT_ERROR_MSG = "No Wind River/Kubernetes API capable of answering your question was found!\nPleasy try again with another prompt."
+CLIENT_ERROR_MSG = "No Wind River/Kubernetes API capable of answering your question was found!\nPleasy try again with another prompt."  # noqa: E501
 
 LOG = logging.getLogger("chatbot")
 
-MODEL = 'meta.llama2-13b-chat-v1'
+MODEL = 'meta.llama2-70b-chat-v1'
+
+LLAMA_PROMPT_END = "Do not acknowledge my request with 'sure' or in any other way besides going straight to the answer. Do not respond with anything more than the answer. Guarantee that the format is followed."  # noqa: E501


### PR DESCRIPTION
# Description

This change updates all calls to the Bedrock API to include a common ending to all Llama prompts. The phrase "Do not acknowledge my request with 'sure' or in any other way besides going straight to the answer. Do not respond with anything more than the answer. Guarantee that the format is followed." is required for some of the prompts used here, and because of that, we should set it as a constant, so if it needs to change we only have to do it in one place.

Apart from that, this change also fixes some PEP 8 errors on lines that had more than 100 characters. For those lines, if they're not prompt strings, they were separated so the maximum char number per line was not reached. This does not impact the functionality.

As a final touch, it changes the model from Llama 13B to 70B, as it was proven to be more consistent and less error prone.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Build Docker image
- [x] Run docker compose up
- [x] From another terminal issue `SESSION_TOKEN=$(curl -H "temperature:0" -H "model:meta.llama2-70b-chat-v1" http://localhost:2000/session) && curl -i -H "Content-Type: application/json" -d '{"message": "How many pods I have?", "session_id": "'"$SESSION_TOKEN"'"}' http://localhost:2000/chat`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
